### PR TITLE
feat: add VS Code extension stub for Crucible (#14)

### DIFF
--- a/extensions/vscode/.gitignore
+++ b/extensions/vscode/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+out/
+.vscode-test/
+*.vsix

--- a/extensions/vscode/README.md
+++ b/extensions/vscode/README.md
@@ -1,0 +1,39 @@
+# Crucible Security Scanner (VS Code Extension Stub)
+
+This is an early Alpha/Stub VS Code extension for the [Crucible](https://github.com/crucible-security/crucible) security framework.
+
+It allows developers to trigger Crucible agent scans directly from their editor by simply providing a target URL. The extension will automatically open a terminal and execute the `crucible scan` command for you, letting you track the results and your final grade directly within VS Code.
+
+## Features
+
+- **Crucible: Scan Agent**: A command available in the Command Palette (`Ctrl+Shift+P` / `Cmd+Shift+P`).
+- **Target URL Prompt**: Prompts for a target URL if you haven't set a default in your settings.
+- **Visual Feedback**: Automatically opens an integrated terminal and runs the scan with the rich UI.
+
+## Extension Settings
+
+This extension contributes the following settings:
+
+* `crucible.defaultTargetUrl`: The default target URL for your agent scans. Set this to avoid being prompted on every scan.
+
+## Install from Source
+
+Currently, this extension is a stub and is **not** published to the VS Code Marketplace. You must run it locally.
+
+### Prerequisites
+1. Ensure you have [Node.js](https://nodejs.org/) installed.
+2. Ensure you have the `crucible` CLI installed in your Python environment and available in your VS Code terminal's PATH.
+
+### Building & Running
+1. Open this `extensions/vscode` folder in VS Code.
+2. Open a terminal and run `npm install` to install the dependencies.
+3. Press `F5` to open a new VS Code window with the extension loaded in "Extension Development Host" mode.
+4. In the new window, open the Command Palette (`Ctrl+Shift+P` or `Cmd+Shift+P`) and run **"Crucible: Scan Agent"**.
+5. Enter your URL and watch the scan execute in the terminal!
+
+## Building the `.vsix` Package
+
+If you want to install it permanently in your regular VS Code without `F5`:
+1. Run `npx @vscode/vsce package` inside this directory.
+2. It will generate a `crucible-vscode-0.1.0.vsix` file.
+3. Install it via the Command Palette: **"Extensions: Install from VSIX..."**.

--- a/extensions/vscode/package-lock.json
+++ b/extensions/vscode/package-lock.json
@@ -1,0 +1,58 @@
+{
+  "name": "crucible-vscode",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "crucible-vscode",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@types/node": "^20.0.0",
+        "@types/vscode": "^1.80.0",
+        "typescript": "^5.0.0"
+      },
+      "engines": {
+        "vscode": "^1.80.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.39",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
+      "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/vscode": {
+      "version": "1.116.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.116.0.tgz",
+      "integrity": "sha512-sYHp4MO6BqJ2PD7Hjt0hlIS3tMaYsVPJrd0RUjDJ8HtOYnyJIEej0bLSccM8rE77WrC+Xox/kdBwEFDO8MsxNA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "crucible-vscode",
+  "displayName": "Crucible Security Scanner",
+  "description": "Run Crucible security scans directly from VS Code",
+  "version": "0.1.0",
+  "publisher": "crucible-security",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/crucible-security/crucible.git"
+  },
+  "engines": {
+    "vscode": "^1.80.0"
+  },
+  "categories": [
+    "Other",
+    "Testing"
+  ],
+  "activationEvents": [],
+  "main": "./out/extension.js",
+  "contributes": {
+    "commands": [
+      {
+        "command": "crucible.scan",
+        "title": "Crucible: Scan Agent"
+      }
+    ],
+    "configuration": {
+      "title": "Crucible Security",
+      "properties": {
+        "crucible.defaultTargetUrl": {
+          "type": "string",
+          "default": "",
+          "description": "The default target URL for Crucible agent scans. If left empty, you will be prompted each time."
+        }
+      }
+    }
+  },
+  "scripts": {
+    "vscode:prepublish": "npm run compile",
+    "compile": "tsc -p ./",
+    "watch": "tsc -watch -p ./"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "@types/vscode": "^1.80.0",
+    "typescript": "^5.0.0"
+  }
+}

--- a/extensions/vscode/src/extension.ts
+++ b/extensions/vscode/src/extension.ts
@@ -1,0 +1,42 @@
+import * as vscode from 'vscode';
+
+export function activate(context: vscode.ExtensionContext) {
+    let disposable = vscode.commands.registerCommand('crucible.scan', async () => {
+        // Read the target URL from configuration
+        const config = vscode.workspace.getConfiguration('crucible');
+        let targetUrl = config.get<string>('defaultTargetUrl');
+
+        // If no default target URL is set, prompt the user
+        if (!targetUrl) {
+            targetUrl = await vscode.window.showInputBox({
+                prompt: 'Enter the target agent URL to scan',
+                placeHolder: 'https://example.com/api/chat',
+                ignoreFocusOut: true
+            });
+        }
+
+        // Exit if no URL is provided
+        if (!targetUrl) {
+            vscode.window.showWarningMessage('Crucible scan cancelled: No target URL provided.');
+            return;
+        }
+
+        // Find existing terminal or create a new one
+        const terminalName = 'Crucible Scan';
+        let terminal = vscode.window.terminals.find(t => t.name === terminalName);
+        if (!terminal) {
+            terminal = vscode.window.createTerminal(terminalName);
+        }
+
+        // Show the terminal and send the scan command
+        terminal.show();
+        terminal.sendText(`crucible scan --target "${targetUrl}"`);
+
+        // Show a notification
+        vscode.window.showInformationMessage(`Crucible scan started for ${targetUrl}. Check the terminal for your grade!`);
+    });
+
+    context.subscriptions.push(disposable);
+}
+
+export function deactivate() {}

--- a/extensions/vscode/tsconfig.json
+++ b/extensions/vscode/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "ES2022",
+    "outDir": "out",
+    "lib": [
+      "ES2022"
+    ],
+    "sourceMap": true,
+    "rootDir": "src",
+    "strict": true
+  },
+  "exclude": [
+    "node_modules",
+    ".vscode-test"
+  ]
+}


### PR DESCRIPTION
This PR resolves Issue #14 by introducing a Minimal Viable Product (stub) for a Crucible VS Code extension.

**What was built:**
- Created a new TypeScript VS Code extension inside `extensions/vscode/`.
- Configured the extension manifest (`package.json`) to register the `crucible.scan` command and a `crucible.defaultTargetUrl` workspace setting.
- Implemented `src/extension.ts` to seamlessly prompt developers for a target URL and execute `crucible scan --target <URL>` directly inside an integrated VS Code terminal.
- Added a `README.md` containing local installation and test instructions for developers.
- Ensured strict typing and configured `.gitignore` to prevent committing compiled JS and `node_modules`.

This lays the architectural foundation for deep editor integration in future updates.
