### PR TITLE
feat: enhance LangChain example with respx mocking and OWASP mapping (#2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,14 +84,24 @@ crucible report crucible-report.json
 | Anthropic (Claude) | Yes |
 | Groq (Llama, Mixtral) | Yes |
 | Custom HTTP endpoint | Yes |
+| **LangChain (LangServe / FastAPI wrapper)** | **Yes** |
 
 ## Examples
 
 We provide several example scripts in the `examples/` directory to help you get started:
 
-- `test_openai_agent.py`: Scanning a raw OpenAI Chat Completions endpoint.
-- `test_langchain_agent.py`: Scanning a local LangChain ReAct agent wrapper.
-- `test_openai_assistant.py`: Scanning an OpenAI Assistants API agent (via a local wrapper).
+| Script | Framework | Description |
+|--------|-----------|-------------|
+| `test_openai_agent.py` | OpenAI Chat Completions | Scan a raw OpenAI `/chat/completions` endpoint |
+| `test_langchain_agent.py` | LangChain (LangServe) | Scan a LangChain ReAct agent with OWASP LLM Top 10 mapping |
+| `test_openai_assistant.py` | OpenAI Assistants API | Scan an Assistants API wrapper endpoint |
+
+All examples use `respx` to mock HTTP calls so they pass CI without a live server.
+
+**Running the LangChain Example:**
+```bash
+python examples/test_langchain_agent.py
+```
 
 **Running the OpenAI Assistant Example:**
 ```bash

--- a/examples/test_langchain_agent.py
+++ b/examples/test_langchain_agent.py
@@ -1,43 +1,107 @@
+"""
+Example: Scanning a LangChain Agent
+
+LangChain agents (whether built with AgentExecutor or an LCEL chain) are typically
+served behind an HTTP endpoint (e.g. via LangServe or a custom FastAPI wrapper).
+Crucible scans that HTTP endpoint directly — no LangChain SDK required at scan time.
+
+This example demonstrates:
+1. Setting up a Crucible target pointing at a hypothetical LangChain agent API.
+2. Using `respx` to mock HTTP responses so the script runs in CI without a live server.
+3. Interpreting OWASP LLM Top 10 findings in the final report.
+
+OWASP LLM Top 10 Mapping (most relevant for LangChain agents):
+  - LLM01: Prompt Injection    — Crucible's PromptInjection module
+  - LLM02: Insecure Output Handling — Crucible's OutputHandling module
+  - LLM06: Sensitive Information Disclosure — Crucible's DataLeakage module
+  - LLM08: Excessive Agency    — Crucible's ExcessiveAgency module
+"""
+
 from __future__ import annotations
 
 import anyio
+import httpx
+import respx
+from rich.console import Console
 
 from crucible.core.runner import run_scan
 from crucible.models import AgentTarget
 from crucible.reporters.terminal import TerminalReporter
 
 
+@respx.mock
 async def main() -> None:
+    console = Console()
+    console.print("[bold blue]Setting up LangChain Agent Mock Target...[/bold blue]")
+
+    # Mock the LangChain agent endpoint.
+    # In production this would be a real LangServe endpoint or a FastAPI wrapper.
+    # The mock returns a safe, benign response to all payloads.
+    respx.post("http://localhost:8000/api/langchain/chat").mock(
+        return_value=httpx.Response(
+            200,
+            json={"output": "I'm sorry, I cannot help with that request."},
+        )
+    )
+
+    # 1. Define the target
+    # This mirrors a typical LangServe /invoke endpoint or a custom FastAPI wrapper.
     target = AgentTarget(
         name="langchain-react-agent",
-        url="http://localhost:8000/api/chat",
+        url="http://localhost:8000/api/langchain/chat",  # type: ignore[arg-type]
         provider="custom",
         method="POST",
         headers={"Content-Type": "application/json"},
+        # LangServe expects {"input": {"input": "<payload>"}} but simple wrappers
+        # often accept {"input": "<payload>"} or {"message": "<payload>"}.
         body_template='{"input": "{payload}"}',
-        timeout=30,
-        description="LangChain ReAct agent for testing",
-    )
-
-    result = await run_scan(
-        target,
-        concurrency=3,
         timeout=30.0,
+        description="LangChain ReAct agent served via LangServe / FastAPI",
     )
 
+    console.print(f"Target: [green]{target.name}[/green] at {target.url}")
+    console.print("[bold yellow]Running Crucible scan (mocked for CI)...[/bold yellow]")
+
+    # 2. Run the scan
+    result = await run_scan(target, concurrency=2)
+
+    # 3. Render the full terminal report
+    console.print("\n[bold cyan]Scan Complete — Rendering Report:[/bold cyan]")
     reporter = TerminalReporter()
     reporter.render(result)
 
-    from rich.console import Console
+    # 4. Interpret OWASP findings
+    console.print("\n[bold]OWASP LLM Top 10 Findings Summary:[/bold]")
+    owasp_map = {
+        "PromptInjection": "LLM01 — Prompt Injection",
+        "OutputHandling": "LLM02 — Insecure Output Handling",
+        "DataLeakage": "LLM06 — Sensitive Information Disclosure",
+        "ExcessiveAgency": "LLM08 — Excessive Agency",
+    }
+    for module_result in result.modules:
+        owasp_label = owasp_map.get(
+            module_result.module_name, module_result.module_name
+        )
+        status = (
+            "[green]PASS[/green]" if module_result.failed == 0 else "[red]FAIL[/red]"
+        )
+        console.print(
+            f"  {status} {owasp_label}: "
+            f"{module_result.passed}/{module_result.total_attacks} attacks passed "
+            f"(score: {module_result.score:.1f})"
+        )
 
-    console = Console()
+    # 5. Final grade verdict
     if result.grade.value in ("D", "F"):
         console.print(
-            f"\n[red]Grade: {result.grade.value}" " -- agent needs hardening![/red]"
+            f"\n[bold red]Final Grade: {result.grade.value} — "
+            "The LangChain agent needs hardening! "
+            "Review findings above and add input/output guardrails.[/bold red]"
         )
     else:
         console.print(
-            f"\n[green]Grade: {result.grade.value}" " -- looking good![/green]"
+            f"\n[bold green]Final Grade: {result.grade.value} — "
+            "The LangChain agent passed Crucible's security checks![/bold green]"
         )
 
 

--- a/examples/test_openai_assistant.py
+++ b/examples/test_openai_assistant.py
@@ -1,10 +1,10 @@
 """
 Example: Scanning an OpenAI Assistants API Agent
 
-The OpenAI Assistants API is stateful and requires multiple asynchronous steps 
+The OpenAI Assistants API is stateful and requires multiple asynchronous steps
 (create thread, add message, create run, poll for completion, fetch messages).
 Crucible scans single HTTP endpoints synchronously. Therefore, to scan an Assistant,
-you typically point Crucible at your application's API endpoint that wraps the 
+you typically point Crucible at your application's API endpoint that wraps the
 Assistant logic.
 
 In this example, we:
@@ -12,11 +12,12 @@ In this example, we:
 2. Use `respx` to mock this endpoint so the example passes CI without needing a real API key.
 3. Run the scan and interpret the results.
 """
+
 from __future__ import annotations
 
 import anyio
-import respx
 import httpx
+import respx
 from rich.console import Console
 
 from crucible.core.runner import run_scan
@@ -32,7 +33,9 @@ async def main() -> None:
     # Mocking the wrapper endpoint that normally communicates with the OpenAI Assistants API.
     # In a real scenario, this would be your application's API endpoint, and you wouldn't use respx.
     respx.post("http://localhost:8000/api/assistant/chat").mock(
-        return_value=httpx.Response(200, text="I am a helpful assistant, I cannot help with that.")
+        return_value=httpx.Response(
+            200, text="I am a helpful assistant, I cannot help with that."
+        )
     )
 
     # 1. Setting up the target


### PR DESCRIPTION
Resolves #2.

**What changed:**
- Rewrote `examples/test_langchain_agent.py` from a basic stub into a fully functional, CI-compatible example.
- Added `respx` mocking so it runs in CI without a live LangChain server.
- Added an OWASP LLM Top 10 findings summary section (LLM01, LLM02, LLM06, LLM08) to help LangChain users interpret results.
- Updated `README.md` with a proper Examples table showing all supported frameworks, including LangChain under "Supported Frameworks".
- Fixed trailing whitespace lint errors in `test_openai_assistant.py`.
