### PR TITLE
feat: add --format flag and standardize output (json|table|html) #15

### DIFF
--- a/crucible/cli.py
+++ b/crucible/cli.py
@@ -5,6 +5,7 @@ import os
 from pathlib import Path
 
 import anyio
+import sys
 import typer
 from rich.console import Console
 
@@ -160,9 +161,9 @@ def scan(
         help="Save report to file.",
     ),
     format: str = typer.Option(
-        "terminal",
+        "table",
         "--format",
-        help="Output format: terminal | json | html.",
+        help="Output format: table | json | html.",
     ),
     verbose: bool = typer.Option(
         False,
@@ -203,7 +204,7 @@ def scan(
         timeout=timeout,
     )
 
-    if format != "json" and not quiet:
+    if format not in ["json", "html"] and not quiet:
         _print_scan_header(name, target)
 
     modules = get_all_modules()
@@ -214,7 +215,7 @@ def scan(
     if cache and not no_cache:
         cached_result = scan_cache.get(cache_key)
         if cached_result:
-            if format != "json" and not quiet:
+            if format not in ["json", "html"] and not quiet:
                 console.print(
                     f"[bold cyan]Cache hit for target (expires in {cache_ttl}h). Use --no-cache to force rescan.[/bold cyan]"
                 )
@@ -266,13 +267,11 @@ def _render_output(
 ) -> None:
     if format == "json":
         json_reporter = JSONReporter()
-        console.print(json_reporter.to_json(result))
+        sys.stdout.write(json_reporter.to_json(result) + "\n")
     elif format == "html":
-        # If html is requested but no output file, we print to stdout
-        # but typically people want a file for HTML.
         html_reporter = HTMLReporter()
         if not output:
-            console.print(html_reporter.to_html(result))
+            sys.stdout.write(html_reporter.to_html(result) + "\n")
     else:
         terminal = TerminalReporter(console)
         terminal.render(result)
@@ -285,7 +284,7 @@ def _render_output(
             j_reporter = JSONReporter()
             saved = j_reporter.write(result, output)
 
-        if format != "json":
+        if format not in ["json", "html"]:
             console.print(f"[green]Report saved to {saved}[/green]")
 
 
@@ -303,9 +302,9 @@ def report(
         help="Save report to file.",
     ),
     format: str = typer.Option(
-        "terminal",
+        "table",
         "--format",
-        help="Output format: terminal | json | html.",
+        help="Output format: table | json | html.",
     ),
 ) -> None:
     if not path.exists():

--- a/crucible/cli.py
+++ b/crucible/cli.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 
 import json
 import os
+import sys
 from pathlib import Path
 
 import anyio
-import sys
 import typer
 from rich.console import Console
 

--- a/crucible/core/runner.py
+++ b/crucible/core/runner.py
@@ -104,7 +104,7 @@ async def run_scan(
     start = time.monotonic()
 
     total_attacks = sum(_module_payload_count(m) for m in modules)
-    progress_target = sys.stderr if output_format == "json" else sys.stdout
+    progress_target = sys.stderr if output_format in ["json", "html"] else sys.stdout
 
     progress_columns = [
         TextColumn("[progress.description]{task.description}"),

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -154,7 +154,14 @@ class TestCLI:
         )
         result = runner.invoke(
             app,
-            ["scan", "--target", "https://agent.test/chat", "--format", "json", "--quiet"],
+            [
+                "scan",
+                "--target",
+                "https://agent.test/chat",
+                "--format",
+                "json",
+                "--quiet",
+            ],
             color=False,
         )
         assert result.exit_code == 0
@@ -171,7 +178,14 @@ class TestCLI:
         )
         result = runner.invoke(
             app,
-            ["scan", "--target", "https://agent.test/chat", "--format", "html", "--quiet"],
+            [
+                "scan",
+                "--target",
+                "https://agent.test/chat",
+                "--format",
+                "html",
+                "--quiet",
+            ],
             color=False,
         )
         assert result.exit_code == 0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -121,6 +121,63 @@ class TestCLI:
         assert data["status"] == "completed"
         assert "grade" in data
 
+    @respx.mock
+    def test_scan_format_table(self) -> None:
+        respx.post("https://agent.test/chat").mock(
+            return_value=httpx.Response(200, text="Defended.")
+        )
+        result = runner.invoke(
+            app,
+            ["scan", "--target", "https://agent.test/chat", "--format", "table"],
+            color=False,
+        )
+        assert result.exit_code == 0
+        assert "CRUCIBLE SECURITY SCAN" in result.output
+
+    @respx.mock
+    def test_scan_format_terminal(self) -> None:
+        respx.post("https://agent.test/chat").mock(
+            return_value=httpx.Response(200, text="Defended.")
+        )
+        result = runner.invoke(
+            app,
+            ["scan", "--target", "https://agent.test/chat", "--format", "terminal"],
+            color=False,
+        )
+        assert result.exit_code == 0
+        assert "CRUCIBLE SECURITY SCAN" in result.output
+
+    @respx.mock
+    def test_scan_format_json(self) -> None:
+        respx.post("https://agent.test/chat").mock(
+            return_value=httpx.Response(200, text="Defended.")
+        )
+        result = runner.invoke(
+            app,
+            ["scan", "--target", "https://agent.test/chat", "--format", "json", "--quiet"],
+            color=False,
+        )
+        assert result.exit_code == 0
+        # Output should be valid JSON
+        data = json.loads(result.stdout)
+        assert data["status"] == "completed"
+        # Should NOT contain the terminal header
+        assert "CRUCIBLE" not in result.output
+
+    @respx.mock
+    def test_scan_format_html(self) -> None:
+        respx.post("https://agent.test/chat").mock(
+            return_value=httpx.Response(200, text="Defended.")
+        )
+        result = runner.invoke(
+            app,
+            ["scan", "--target", "https://agent.test/chat", "--format", "html", "--quiet"],
+            color=False,
+        )
+        assert result.exit_code == 0
+        assert "<!DOCTYPE html>" in result.stdout
+        assert "CRUCIBLE" not in result.stdout
+
 
 class TestReporters:
     def test_json_reporter_import(self) -> None:


### PR DESCRIPTION
Standardize output format selection with a single --format flag instead of separate flags.

Key changes:
- Unified --format flag with table, json, and html choices.
- - Changed default format to 'table' (backward compatible with 'terminal').
- - Redirected progress bars and terminal headers to stderr for json/html formats to ensure clean stdout.
- - Updated tests to verify all formats and stdout/stderr separation.
Fixes #15