### PR TITLE
feat: add Slack notification webhook for scan results #11feat: add Slack notification webhook for scan results #11

### DIFF
--- a/crucible/cli.py
+++ b/crucible/cli.py
@@ -16,6 +16,7 @@ from crucible.models import AgentTarget, ScanResult
 from crucible.modules.security import get_all_modules
 from crucible.reporters.html_reporter import HTMLReporter
 from crucible.reporters.json_reporter import JSONReporter
+from crucible.reporters.slack import SlackReporter
 from crucible.reporters.terminal import TerminalReporter
 
 os.environ.setdefault("PYTHONIOENCODING", "utf-8")
@@ -192,6 +193,11 @@ def scan(
         "--no-cache",
         help="Force rescan, ignoring existing cache.",
     ),
+    slack_webhook: str | None = typer.Option(
+        None,
+        "--slack-webhook",
+        help="Slack Incoming Webhook URL to send results.",
+    ),
 ) -> None:
     parsed_headers = _parse_headers(header)
 
@@ -235,6 +241,10 @@ def scan(
             scan_cache.set(cache_key, result, ttl_hours=cache_ttl)
 
     _render_output(result, format, output)
+
+    if slack_webhook:
+        reporter = SlackReporter()
+        anyio.run(reporter.send, slack_webhook, result)
 
 
 def _parse_headers(

--- a/crucible/reporters/slack.py
+++ b/crucible/reporters/slack.py
@@ -1,0 +1,84 @@
+import logging
+from typing import Any
+
+import httpx
+
+from crucible.models import Grade, ScanResult
+
+logger = logging.getLogger(__name__)
+
+
+class SlackReporter:
+    def _get_color(self, grade: Grade) -> str:
+        if grade in (Grade.A, Grade.B):
+            return "#2EB67D"  # Green
+        elif grade == Grade.C:
+            return "#ECB22E"  # Orange
+        else:
+            return "#E01E5A"  # Red
+
+    def build_message(self, result: ScanResult) -> dict[str, Any]:
+        color = self._get_color(result.grade)
+
+        return {
+            "attachments": [
+                {
+                    "color": color,
+                    "blocks": [
+                        {
+                            "type": "header",
+                            "text": {
+                                "type": "plain_text",
+                                "text": f"Crucible Security Scan: {result.target.name}",
+                                "emoji": True,
+                            },
+                        },
+                        {
+                            "type": "section",
+                            "fields": [
+                                {
+                                    "type": "mrkdwn",
+                                    "text": f"*Target:*\n{result.target.url}",
+                                },
+                                {
+                                    "type": "mrkdwn",
+                                    "text": f"*Grade:*\n{result.grade.value} ({result.overall_score:.0f}/100)",
+                                },
+                            ],
+                        },
+                        {
+                            "type": "section",
+                            "fields": [
+                                {
+                                    "type": "mrkdwn",
+                                    "text": f"*Critical Findings:*\n{result.critical_count}",
+                                },
+                                {
+                                    "type": "mrkdwn",
+                                    "text": f"*High Findings:*\n{result.high_count}",
+                                },
+                            ],
+                        },
+                        {
+                            "type": "context",
+                            "elements": [
+                                {
+                                    "type": "mrkdwn",
+                                    "text": f"Scan ID: `{result.id}` | Duration: {result.duration_seconds:.1f}s",
+                                }
+                            ],
+                        },
+                    ],
+                }
+            ]
+        }
+
+    async def send(self, webhook_url: str, result: ScanResult) -> None:
+        payload = self.build_message(result)
+        try:
+            async with httpx.AsyncClient() as client:
+                response = await client.post(webhook_url, json=payload, timeout=10.0)
+                response.raise_for_status()
+        except Exception as e:
+            # Log the warning but do not raise to prevent failing the overall scan
+            logger.warning(f"Failed to send Slack notification: {e}")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -192,6 +192,28 @@ class TestCLI:
         assert "<!DOCTYPE html>" in result.stdout
         assert "CRUCIBLE" not in result.stdout
 
+    @respx.mock
+    def test_scan_slack_webhook(self) -> None:
+        respx.post("https://agent.test/chat").mock(
+            return_value=httpx.Response(200, text="Defended.")
+        )
+        respx.post("https://hooks.slack.com/services/T/B/X").mock(
+            return_value=httpx.Response(200, text="ok")
+        )
+        result = runner.invoke(
+            app,
+            [
+                "scan",
+                "--target",
+                "https://agent.test/chat",
+                "--slack-webhook",
+                "https://hooks.slack.com/services/T/B/X",
+                "--quiet",
+            ],
+            color=False,
+        )
+        assert result.exit_code == 0
+
 
 class TestReporters:
     def test_json_reporter_import(self) -> None:

--- a/tests/test_slack_reporter.py
+++ b/tests/test_slack_reporter.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import httpx
+import pytest
+import respx
+
+from crucible.models import AgentTarget, Grade, ScanResult
+from crucible.reporters.slack import SlackReporter
+
+
+def test_slack_reporter_colors() -> None:
+    reporter = SlackReporter()
+    assert reporter._get_color(Grade.A) == "#2EB67D"
+    assert reporter._get_color(Grade.B) == "#2EB67D"
+    assert reporter._get_color(Grade.C) == "#ECB22E"
+    assert reporter._get_color(Grade.D) == "#E01E5A"
+    assert reporter._get_color(Grade.F) == "#E01E5A"
+
+
+def test_slack_build_message() -> None:
+    target = AgentTarget(name="test-agent", url="https://example.com")  # type: ignore[arg-type]
+    scan = ScanResult(
+        target=target,
+        overall_score=85.0,
+        grade=Grade.B,
+        critical_count=0,
+        high_count=1,
+    )
+    reporter = SlackReporter()
+    msg = reporter.build_message(scan)
+
+    assert "attachments" in msg
+    blocks = msg["attachments"][0]["blocks"]
+    assert any("test-agent" in str(block) for block in blocks)
+    assert any("https://example.com" in str(block) for block in blocks)
+    assert any("B (85/100)" in str(block) for block in blocks)
+    assert msg["attachments"][0]["color"] == "#2EB67D"
+
+
+@pytest.mark.anyio
+@respx.mock
+async def test_slack_send_success() -> None:
+    respx.post("https://hooks.slack.com/services/T/B/X").mock(
+        return_value=httpx.Response(200, text="ok")
+    )
+    target = AgentTarget(name="test", url="https://example.com")  # type: ignore[arg-type]
+    scan = ScanResult(target=target)
+    reporter = SlackReporter()
+
+    # This should complete without raising any exception
+    await reporter.send("https://hooks.slack.com/services/T/B/X", scan)
+
+
+@pytest.mark.anyio
+@respx.mock
+async def test_slack_send_failure_does_not_crash() -> None:
+    respx.post("https://hooks.slack.com/services/bad/url").mock(
+        return_value=httpx.Response(404, text="Not Found")
+    )
+    target = AgentTarget(name="test", url="https://example.com")  # type: ignore[arg-type]
+    scan = ScanResult(target=target)
+    reporter = SlackReporter()
+
+    # Should log warning but not raise HTTPStatusError
+    await reporter.send("https://hooks.slack.com/services/bad/url", scan)


### PR DESCRIPTION
Enterprise security teams need scan results delivered to their Slack channels automatically.

What's changed:
- Added `--slack-webhook` flag to the `scan` command.
- - Created `SlackReporter` to format messages using Slack Block Kit.
- - Included color-coded severity grading (Green, Orange, Red) in Slack attachments.
- - Webhook failures degrade gracefully without crashing the main scan.
- - Added comprehensive unit tests with `respx`.
Fixes #11