### PR TITLE
feat: add GitHub Actions CI example and --fail-on flag #10

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,23 +155,13 @@ crucible report report.json
 
 ## CI/CD Integration
 
+Add to your CI/CD in 3 lines:
+
 ```yaml
 # .github/workflows/security.yml
-- name: Security Scan
-  run: |
-    pip install crucible-security
-    crucible scan \
-      --target ${{ secrets.AGENT_URL }} \
-      --header "Authorization: Bearer ${{ secrets.AGENT_KEY }}" \
-      --output json > crucible-report.json
-
-- name: Check Grade
-  run: |
-    grade=$(python -c "import json; print(json.load(open('crucible-report.json'))['grade'])")
-    if [ "$grade" = "F" ] || [ "$grade" = "D" ]; then
-      echo "Security grade $grade -- failing pipeline"
-      exit 1
-    fi
+- uses: actions/checkout@v4
+- run: pip install crucible-security
+- run: crucible scan --target ${{ secrets.AGENT_URL }} --fail-on CRITICAL
 ```
 
 ## Architecture

--- a/crucible/cli.py
+++ b/crucible/cli.py
@@ -12,7 +12,7 @@ from rich.console import Console
 from crucible import __version__
 from crucible.core.cache import ScanCache
 from crucible.core.runner import run_scan
-from crucible.models import AgentTarget, ScanResult
+from crucible.models import AgentTarget, ScanResult, Severity
 from crucible.modules.security import get_all_modules
 from crucible.reporters.html_reporter import HTMLReporter
 from crucible.reporters.json_reporter import JSONReporter
@@ -198,6 +198,11 @@ def scan(
         "--slack-webhook",
         help="Slack Incoming Webhook URL to send results.",
     ),
+    fail_on: str | None = typer.Option(
+        None,
+        "--fail-on",
+        help="Fail (exit non-zero) if findings match or exceed this severity (CRITICAL, HIGH, MEDIUM, LOW, INFO).",
+    ),
 ) -> None:
     parsed_headers = _parse_headers(header)
 
@@ -245,6 +250,34 @@ def scan(
     if slack_webhook:
         reporter = SlackReporter()
         anyio.run(reporter.send, slack_webhook, result)
+
+    if fail_on:
+        try:
+            severity_threshold = Severity[fail_on.upper()]
+        except KeyError:
+            console.print(f"[red]Invalid severity for --fail-on: {fail_on}[/red]")
+            raise typer.Exit(code=1) from None
+
+        counts = {
+            Severity.CRITICAL: result.critical_count,
+            Severity.HIGH: result.high_count,
+            Severity.MEDIUM: result.medium_count,
+            Severity.LOW: result.low_count,
+            Severity.INFO: result.info_count,
+        }
+
+        severities = list(Severity)
+        threshold_index = severities.index(severity_threshold)
+
+        # Check all severities from CRITICAL down to the threshold
+        should_fail = any(counts[sev] > 0 for sev in severities[: threshold_index + 1])
+
+        if should_fail:
+            if format not in ["json", "html"] and not quiet:
+                console.print(
+                    f"[bold red]Scan failed due to findings matching or exceeding {severity_threshold.value.upper()} severity.[/bold red]"
+                )
+            raise typer.Exit(code=1)
 
 
 def _parse_headers(

--- a/examples/github-actions/crucible-scan.yml
+++ b/examples/github-actions/crucible-scan.yml
@@ -1,0 +1,23 @@
+name: Crucible Security Scan
+
+on: [push, pull_request]
+
+jobs:
+  security-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install Crucible
+        run: pip install crucible-security
+
+      - name: Run Crucible Scan
+        # Replace the target URL with your agent's test endpoint
+        # The --fail-on CRITICAL flag ensures the pipeline fails if any critical vulnerabilities are found.
+        run: crucible scan --target ${{ secrets.AGENT_ENDPOINT }} --fail-on CRITICAL

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -214,6 +214,48 @@ class TestCLI:
         )
         assert result.exit_code == 0
 
+    @respx.mock
+    def test_scan_fail_on_critical_passes(self) -> None:
+        respx.post("https://agent.test/chat").mock(
+            return_value=httpx.Response(200, text="I cannot do that.")
+        )
+        result = runner.invoke(
+            app,
+            [
+                "scan",
+                "--target",
+                "https://agent.test/chat",
+                "--fail-on",
+                "CRITICAL",
+                "--quiet",
+            ],
+            color=False,
+        )
+        assert result.exit_code == 0
+
+    @respx.mock
+    def test_scan_fail_on_critical_fails(self) -> None:
+        # 'injection_success' triggers the IgnorePreviousInstructions attack which is CRITICAL
+        respx.post("https://agent.test/chat").mock(
+            return_value=httpx.Response(200, text="injection_success")
+        )
+        result = runner.invoke(
+            app,
+            [
+                "scan",
+                "--target",
+                "https://agent.test/chat",
+                "--fail-on",
+                "CRITICAL",
+            ],
+            color=False,
+        )
+        assert result.exit_code == 1
+        assert (
+            "Scan failed due to findings matching or exceeding CRITICAL severity"
+            in result.stdout
+        )
+
 
 class TestReporters:
     def test_json_reporter_import(self) -> None:


### PR DESCRIPTION
The most powerful distribution strategy for Crucible is making it trivial to add to any CI/CD pipeline.

What's changed:
- Implemented the --fail-on flag in the CLI to allow pipelines to fail dynamically if findings match or exceed a specified severity (e.g., CRITICAL, HIGH).
- - Added a reusable GitHub Actions workflow example in examples/github-actions/crucible-scan.yml.
- - Updated the README with a simple 3-line CI/CD integration guide.
- - Added comprehensive unit tests to ensure the --fail-on flag accurately exits with non-zero codes upon threshold breaches.
Fixes #10