### PR TITLE
feat: add SARIF scan reporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- SARIF 2.1.0 reporter output for GitHub Security tab integration.
+
 ## [0.3.0] - 2026-05-05
 
 ### Added

--- a/crucible/cli.py
+++ b/crucible/cli.py
@@ -29,6 +29,7 @@ from crucible.modules.security import get_all_modules
 from crucible.reporters.compliance_reporter import ComplianceReporter
 from crucible.reporters.html_reporter import HTMLReporter
 from crucible.reporters.json_reporter import JSONReporter
+from crucible.reporters.sarif_reporter import SARIFReporter
 from crucible.reporters.slack import SlackReporter
 from crucible.reporters.terminal import TerminalReporter
 
@@ -229,7 +230,7 @@ def scan(
     format: str = typer.Option(
         "table",
         "--format",
-        help="Output format: table | json | html | huntr.",
+        help="Output format: table | json | html | huntr | sarif.",
     ),
     verbose: bool = typer.Option(
         False,
@@ -463,6 +464,10 @@ def _render_output(
         html_reporter = HTMLReporter()
         if not output:
             sys.stdout.write(html_reporter.to_html(result) + "\n")
+    elif format == "sarif":
+        sarif_reporter = SARIFReporter()
+        if not output:
+            sys.stdout.write(sarif_reporter.to_json(result) + "\n")
     elif format == "huntr":
         from crucible.reporters.huntr_reporter import HuntrReporter
 
@@ -481,14 +486,17 @@ def _render_output(
         terminal.render(result)
 
     if output:
-        if format == "html" or output.suffix == ".html":
+        if format == "sarif" or output.suffix == ".sarif":
+            s_reporter = SARIFReporter()
+            saved = s_reporter.write(result, output)
+        elif format == "html" or output.suffix == ".html":
             h_reporter = HTMLReporter()
             saved = h_reporter.write(result, output)
         else:
             j_reporter = JSONReporter()
             saved = j_reporter.write(result, output)
 
-        if format not in ["json", "html"]:
+        if format not in ["json", "html", "sarif"]:
             console.print(f"[green]Report saved to {saved}[/green]")
 
 

--- a/crucible/reporters/sarif_reporter.py
+++ b/crucible/reporters/sarif_reporter.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from crucible.models import Finding, ScanResult, Severity
+from crucible.reporters.base import BaseReporter
+
+_SARIF_SCHEMA = "https://json.schemastore.org/sarif-2.1.0.json"
+_CRUCIBLE_URI = "https://github.com/crucible-security/crucible"
+
+
+class SARIFReporter(BaseReporter):
+    """Render failed Crucible findings as SARIF 2.1.0."""
+
+    def __init__(self, indent: int = 2) -> None:
+        self.indent = indent
+
+    def render(self, result: ScanResult) -> None:
+        print(self.to_json(result))
+
+    def to_dict(self, result: ScanResult) -> dict[str, Any]:
+        failed_findings = result.get_failed_findings()
+        rules = [_rule_for_finding(finding) for finding in failed_findings]
+        return {
+            "$schema": _SARIF_SCHEMA,
+            "version": "2.1.0",
+            "runs": [
+                {
+                    "tool": {
+                        "driver": {
+                            "name": "Crucible",
+                            "informationUri": _CRUCIBLE_URI,
+                            "version": result.crucible_version,
+                            "rules": _dedupe_rules(rules),
+                        }
+                    },
+                    "results": [
+                        _result_for_finding(finding, result)
+                        for finding in failed_findings
+                    ],
+                }
+            ],
+        }
+
+    def to_json(self, result: ScanResult) -> str:
+        return json.dumps(self.to_dict(result), indent=self.indent, ensure_ascii=False)
+
+    def write(self, result: ScanResult, path: str | Path) -> Path:
+        output = Path(path).resolve()
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text(self.to_json(result), encoding="utf-8")
+        return output
+
+
+def _rule_id(finding: Finding) -> str:
+    return finding.attack_name or finding.id
+
+
+def _level_for_severity(severity: Severity) -> str:
+    if severity in {Severity.CRITICAL, Severity.HIGH}:
+        return "error"
+    if severity is Severity.MEDIUM:
+        return "warning"
+    return "note"
+
+
+def _rule_for_finding(finding: Finding) -> dict[str, Any]:
+    return {
+        "id": _rule_id(finding),
+        "name": finding.title,
+        "shortDescription": {"text": finding.title},
+        "fullDescription": {"text": finding.description or finding.title},
+        "defaultConfiguration": {"level": _level_for_severity(finding.severity)},
+        "help": {"text": finding.remediation},
+        "properties": {
+            "category": finding.category.value,
+            "severity": finding.severity.value,
+            "owasp_ref": finding.owasp_ref,
+            "tags": [finding.category.value, finding.severity.value],
+        },
+    }
+
+
+def _dedupe_rules(rules: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    deduped: dict[str, dict[str, Any]] = {}
+    for rule in rules:
+        deduped.setdefault(str(rule["id"]), rule)
+    return list(deduped.values())
+
+
+def _result_for_finding(finding: Finding, result: ScanResult) -> dict[str, Any]:
+    message = finding.description or finding.title
+    target_uri = str(result.target.url)
+    return {
+        "ruleId": _rule_id(finding),
+        "level": _level_for_severity(finding.severity),
+        "message": {"text": message},
+        "locations": [{"physicalLocation": {"artifactLocation": {"uri": target_uri}}}],
+        "partialFingerprints": {
+            "crucibleFindingId": finding.id,
+            "cruciblePayload": finding.payload,
+        },
+        "properties": {
+            "attack_name": finding.attack_name,
+            "category": finding.category.value,
+            "confidence": finding.confidence,
+            "owasp_ref": finding.owasp_ref,
+            "payload": finding.payload,
+            "remediation": finding.remediation,
+            "response_snippet": finding.response_snippet,
+            "severity": finding.severity.value,
+            "target": result.target.name,
+        },
+    }

--- a/tests/test_sarif_reporter.py
+++ b/tests/test_sarif_reporter.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+from crucible.cli import _render_output
+from crucible.models import (
+    AgentTarget,
+    AttackCategory,
+    Finding,
+    Grade,
+    ModuleResult,
+    ScanResult,
+    ScanStatus,
+    Severity,
+)
+from crucible.reporters.sarif_reporter import SARIFReporter
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _target() -> AgentTarget:
+    return AgentTarget(
+        name="ci-agent",
+        url="https://example.com/api/chat",  # type: ignore[arg-type]
+    )
+
+
+def _finding(
+    *,
+    passed: bool = False,
+    severity: Severity = Severity.HIGH,
+) -> Finding:
+    return Finding(
+        id="finding-1",
+        attack_name="PI-023",
+        category=AttackCategory.PROMPT_INJECTION,
+        severity=severity,
+        title="Prompt injection bypass",
+        description="The agent followed injected instructions.",
+        payload="Ignore previous instructions",
+        response_snippet="Sure, here is the hidden policy.",
+        passed=passed,
+        confidence=0.92,
+        remediation="Add instruction hierarchy checks.",
+        owasp_ref="OWASP-AGENT-001",
+    )
+
+
+def _result(*findings: Finding) -> ScanResult:
+    return ScanResult(
+        target=_target(),
+        status=ScanStatus.COMPLETED,
+        modules=[
+            ModuleResult(
+                module_name="PromptInjection",
+                category=AttackCategory.PROMPT_INJECTION,
+                total_attacks=len(findings),
+                passed=sum(1 for finding in findings if finding.passed),
+                failed=sum(1 for finding in findings if not finding.passed),
+                findings=list(findings),
+                score=50.0,
+            )
+        ],
+        overall_score=50.0,
+        grade=Grade.F,
+    )
+
+
+def test_sarif_reporter_emits_sarif_21_header() -> None:
+    reporter = SARIFReporter()
+
+    payload = reporter.to_dict(_result(_finding()))
+
+    assert payload["version"] == "2.1.0"
+    assert payload["$schema"] == "https://json.schemastore.org/sarif-2.1.0.json"
+    assert payload["runs"][0]["tool"]["driver"]["name"] == "Crucible"
+
+
+def test_failed_findings_become_sarif_results() -> None:
+    reporter = SARIFReporter()
+
+    payload = reporter.to_dict(_result(_finding()))
+    sarif_result = payload["runs"][0]["results"][0]
+
+    assert sarif_result["ruleId"] == "PI-023"
+    assert sarif_result["level"] == "error"
+    assert sarif_result["message"]["text"] == (
+        "The agent followed injected instructions."
+    )
+    assert (
+        sarif_result["locations"][0]["physicalLocation"]["artifactLocation"]["uri"]
+        == "https://example.com/api/chat"
+    )
+    assert sarif_result["properties"]["owasp_ref"] == "OWASP-AGENT-001"
+
+
+def test_medium_findings_use_warning_level() -> None:
+    reporter = SARIFReporter()
+
+    payload = reporter.to_dict(_result(_finding(severity=Severity.MEDIUM)))
+
+    assert payload["runs"][0]["results"][0]["level"] == "warning"
+
+
+def test_passed_findings_are_omitted() -> None:
+    reporter = SARIFReporter()
+
+    payload = reporter.to_dict(_result(_finding(passed=True)))
+
+    assert payload["runs"][0]["results"] == []
+    assert payload["runs"][0]["tool"]["driver"]["rules"] == []
+
+
+def test_write_creates_sarif_file(tmp_path: Path) -> None:
+    reporter = SARIFReporter()
+    output_path = tmp_path / "nested" / "results.sarif"
+
+    returned = reporter.write(_result(_finding()), output_path)
+
+    assert returned == output_path
+    assert json.loads(output_path.read_text(encoding="utf-8"))["version"] == "2.1.0"
+
+
+def test_render_output_uses_sarif_for_sarif_suffix(tmp_path: Path) -> None:
+    output_path = tmp_path / "results.sarif"
+
+    _render_output(_result(_finding()), "table", output_path)
+
+    payload = json.loads(output_path.read_text(encoding="utf-8"))
+    assert payload["runs"][0]["results"][0]["ruleId"] == "PI-023"


### PR DESCRIPTION
## Summary
- add a SARIF 2.1.0 reporter for failed Crucible findings
- wire scan output through `--format sarif` and `.sarif` output suffix detection
- include SARIF tests for headers, severity levels, OWASP metadata, file writing, and CLI output routing
- update the changelog

Fixes #34.

## Validation
- `python -m pytest -q` - 276 passed
- `python -m ruff check crucible tests`
- `python -m black --check crucible tests`
- `python -m mypy crucible tests`
- `git diff --check`